### PR TITLE
Fixes#19 empty args object should not generate parentheses

### DIFF
--- a/src/__tests__/arguments.tests.ts
+++ b/src/__tests__/arguments.tests.ts
@@ -161,4 +161,19 @@ describe('jsonToGraphQLQuery() - arguments', () => {
         );
     });
 
+    it('Empty args object should not generate parentheses', () => {
+        const query = {
+            query: {
+                Posts: {
+                    __args: {},
+                    id: true,
+                    title: true
+                }
+            }
+        };
+        expect(jsonToGraphQLQuery(query)).to.equal(
+            'query { Posts { id title } }'
+        );
+    });
+
 });

--- a/src/jsonToGraphQLQuery.ts
+++ b/src/jsonToGraphQLQuery.ts
@@ -93,7 +93,7 @@ function convertQuery(node: any, level: number, output: [string, number][], opti
                 const fieldCount = Object.keys(value)
                     .filter((keyCount) => filterNonConfigFields(keyCount, options.ignoreFields!)).length;
                 const subFields = fieldCount > 0;
-                const argsExist = typeof value.__args === 'object';
+                const argsExist = typeof value.__args === 'object' && Object.keys(value.__args).length > 0;
                 const directivesExist = typeof value.__directives === 'object';
                 const fullFragmentsExist = value.__all_on instanceof Array;
                 const partialFragmentsExist = typeof value.__on === 'object';


### PR DESCRIPTION
Fixes: https://github.com/dupski/json-to-graphql-query/issues/19