### PR TITLE
fixing args / directives order according to gql specs

### DIFF
--- a/src/__tests__/directives.tests.ts
+++ b/src/__tests__/directives.tests.ts
@@ -25,7 +25,7 @@ describe('jsonToGraphQLQuery() - directives', () => {
         } as any;
         expect(jsonToGraphQLQuery(query, { pretty: true })).to.equal(
             `query {
-    Posts @client (where: {id: 10}, orderBy: "flibble") {
+    Posts (where: {id: 10}, orderBy: "flibble") @client {
         id
         title
         post_date
@@ -96,7 +96,7 @@ describe('jsonToGraphQLQuery() - directives', () => {
         } as any;
         expect(jsonToGraphQLQuery(query, { pretty: true })).to.equal(
             `query {
-    Posts @client @withArgs(id: [1, 2, 3]) (where: {id: 10}, orderBy: "flibble") {
+    Posts (where: {id: 10}, orderBy: "flibble") @client @withArgs(id: [1, 2, 3]) {
         id
         title
         post_date

--- a/src/jsonToGraphQLQuery.ts
+++ b/src/jsonToGraphQLQuery.ts
@@ -123,7 +123,7 @@ function convertQuery(node: any, level: number, output: [string, number][], opti
                         argsStr = `(${buildArgs(value.__args)})`;
                     }
                     const spacer = directivesExist && argsExist ? ' ' : '';
-                    token = `${token} ${dirsStr}${spacer}${argsStr}`;
+                    token = `${token} ${argsStr}${spacer}${dirsStr}`;
                 }
 
                 output.push([token + (subFields || partialFragmentsExist || fullFragmentsExist ? ' {' : ''), level]);


### PR DESCRIPTION
Hello,

We noticed an error while using your lib. Your directives should always be declared after your arguments according to gql specs.
Find more information [here](https://spec.graphql.org/June2018/#sec-Language.Fields).

Hope you can merge this soon :dancers: 

Best regards