### PR TITLE
fix: empty object serialization

### DIFF
--- a/src/__tests__/falsykeys.tests.ts
+++ b/src/__tests__/falsykeys.tests.ts
@@ -46,4 +46,40 @@ describe('jsonToGraphQLQuery() - falsy keys', () => {
         );
     });
 
+    it('does not include object with only false keys', () => {
+        const query = {
+            query: {
+                Posts: {
+                    id: true,
+                    name: false
+                },
+                Lorem: {
+                    id: false
+                },
+                Ipsum: true
+            }
+        };
+        expect(jsonToGraphQLQuery(query)).to.equal(
+            'query { Posts { id } Ipsum }'
+        );
+    });
+
+    it('does include object with only false keys if includeFalsyKeys is true', () => {
+        const query = {
+            query: {
+                Posts: {
+                    id: true,
+                    name: false
+                },
+                Lorem: {
+                    id: false
+                },
+                Ipsum: true
+            }
+        };
+        expect(jsonToGraphQLQuery(query, { includeFalsyKeys: true })).to.equal(
+            'query { Posts { id name } Lorem { id } Ipsum }'
+        );
+    });
+
 });

--- a/src/jsonToGraphQLQuery.ts
+++ b/src/jsonToGraphQLQuery.ts
@@ -90,6 +90,12 @@ function convertQuery(node: any, level: number, output: [string, number][], opti
                     }
                 }
 
+                // Check if the object would be empty
+                if (value && Object.keys(value).filter(k => value[k] !== false || options.includeFalsyKeys).length === 0) {
+                    // If so, we don't include it into the query
+                    return;
+                }
+
                 const fieldCount = Object.keys(value)
                     .filter((keyCount) => filterNonConfigFields(keyCount, options.ignoreFields!)).length;
                 const subFields = fieldCount > 0;
@@ -116,7 +122,7 @@ function convertQuery(node: any, level: number, output: [string, number][], opti
                     let dirsStr = '';
                     if (directivesExist) {
                         dirsStr = Object.entries(value.__directives)
-                            .map(item => `@${buildDirectives({[item[0]]: item[1]})}`)
+                            .map(item => `@${buildDirectives({ [item[0]]: item[1] })}`)
                             .join(' ')
                     }
                     if (argsExist) {


### PR DESCRIPTION
The library outputs empty objects to the query which makes the GraphQL service fail with the following error: `Syntax Error: Expected Name, found "}".`. In this fix I change the serialisation process so if the query would result an empty object, it is not included into the final query.